### PR TITLE
Upgrade AWS provider from ~> 5.99 to ~> 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,17 +195,17 @@ If you're currently using the [kreuzwerker/docker](https://github.com/kreuzwerke
 
 ## Requirements
 
-| Name | Version |
-|------|---------|
+| Name      | Version  |
+|-----------|----------|
 | terraform | >= 1.9.1 |
-| aws | ~> 5.99 |
-| null | ~> 3.2.4 |
+| aws       | ~> 6.0   |
+| null      | ~> 3.2.4 |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| aws | ~> 5.99 |
+| Name | Version  |
+|------|----------|
+| aws  | ~> 6.0   |
 | null | ~> 3.2.4 |
 
 

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.99"
+      version = "~> 6.0"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
Updates the AWS provider version requirement from ~> 5.99 to ~> 6.0. This update affects both the README documentation and the versions.tf configuration.

### Changes
- Updated AWS provider version in versions.tf
- Updated corresponding version tables in README.md