### PR TITLE
Skip build if it exists. Perform docker login.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -53,14 +53,14 @@ resource "null_resource" "docker_build" {
 
   provisioner "local-exec" {
     command = <<-CMD
-      if aws ecr describe-images --repository-name ${var.ecr_repo} \
-           --image-ids imageTag=${local.image_tag} \
-           --region ${data.aws_region.current.region} >/dev/null 2>&1; then
+      if aws ecr describe-images --repository-name "${var.ecr_repo}" \
+           --image-ids imageTag="${local.image_tag}" \
+           --region "${data.aws_region.current.region}" >/dev/null 2>&1; then
         echo "Image ${local.image_uri} already in ECR. Skipping build."
       else
-        aws ecr get-login-password --region ${data.aws_region.current.region} \
-          | docker login --username AWS --password-stdin ${local.repository_url}
-        docker buildx build ${join(" ", local.build_args)} ${var.source_path} && echo 'Built and pushed ${local.image_uri}'
+        aws ecr get-login-password --region "${data.aws_region.current.region}" \
+          | docker login --username AWS --password-stdin "${local.repository_url}"
+        docker buildx build ${join(" ", local.build_args)} "${var.source_path}" && echo 'Built and pushed ${local.image_uri}'
       fi
     CMD
   }

--- a/main.tf
+++ b/main.tf
@@ -55,10 +55,10 @@ resource "null_resource" "docker_build" {
     command = <<-CMD
       if aws ecr describe-images --repository-name ${var.ecr_repo} \
            --image-ids imageTag=${local.image_tag} \
-           --region ${data.aws_region.current.name} >/dev/null 2>&1; then
+           --region ${data.aws_region.current.region} >/dev/null 2>&1; then
         echo "Image ${local.image_uri} already in ECR. Skipping build."
       else
-        aws ecr get-login-password --region ${data.aws_region.current.name} \
+        aws ecr get-login-password --region ${data.aws_region.current.region} \
           | docker login --username AWS --password-stdin ${local.repository_url}
         docker buildx build ${join(" ", local.build_args)} ${var.source_path} && echo 'Built and pushed ${local.image_uri}'
       fi

--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,16 @@ resource "null_resource" "docker_build" {
   ]
 
   provisioner "local-exec" {
-    command = "docker buildx build ${join(" ", local.build_args)} ${var.source_path} && echo 'Built and pushed ${local.image_uri}'"
+    command = <<-CMD
+      if aws ecr describe-images --repository-name ${var.ecr_repo} \
+           --image-ids imageTag=${local.image_tag} \
+           --region ${data.aws_region.current.name} >/dev/null 2>&1; then
+        echo "Image ${local.image_uri} already in ECR. Skipping build."
+      else
+        aws ecr get-login-password --region ${data.aws_region.current.name} \
+          | docker login --username AWS --password-stdin ${local.repository_url}
+        docker buildx build ${join(" ", local.build_args)} ${var.source_path} && echo 'Built and pushed ${local.image_uri}'
+      fi
+    CMD
   }
 }


### PR DESCRIPTION
This fixes two minor annoyances:

1) If you switch to a different branch, apply, and then later switch back to the first branch and try to re-apply that, it fails since the images already exists, and you will need to manually delete them.

2) I always forget to run `aws ecr ... | docker login ...` before running my first apply for the day.