### PR TITLE
files sha is deterministic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ locals {
   repository_url = "${data.aws_caller_identity.current.account_id}.dkr.ecr.${data.aws_region.current.region}.amazonaws.com/${var.ecr_repo}"
 
   files          = setunion([for pattern in var.source_files : fileset(var.source_path, pattern)]...)
-  files_sha      = [for f in local.files : filesha256("${var.source_path}/${f}")]
+  files_sha      = sort([for f in local.files : filesha256("${var.source_path}/${f}")])
   dockerfile_sha = filesha256(var.docker_file_path)
   src_sha        = sha256(join("", concat(local.files_sha, [local.dockerfile_sha])))
 


### PR DESCRIPTION
Hashing the files uses `setunion`  which is non-deterministic, causing this to be rebuild even when the files haven't changed


There is potentially one more problem:

```
effective_triggers = coalesce(var.triggers, {
    src_sha         = local.src_sha
    build_args_hash = sha256(jsonencode(var.build_args))
  })
```

`build_args` could contain absolute file paths. This is not a problem with how we use it in [inspect-action](https://github.com/METR/inspect-action), we don't pass absolute paths here.